### PR TITLE
Add DROP TABLE to InitializeDatabase

### DIFF
--- a/spring-boot/src/main/java/springboot/Application.java
+++ b/spring-boot/src/main/java/springboot/Application.java
@@ -2,6 +2,7 @@ package springboot;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import springboot.database.InitializeDatabase;
 import org.springframework.context.annotation.ComponentScan;
 import springboot.database.Setup;
 
@@ -9,7 +10,7 @@ import springboot.database.Setup;
 public class Application {
 
     public static void main(String[] args) {
-        Setup.initialize();
+        InitializeDatabase.main(args);
         SpringApplication.run(Application.class, args);
     }
 }

--- a/spring-boot/src/main/java/springboot/database/InitializeDatabase.java
+++ b/spring-boot/src/main/java/springboot/database/InitializeDatabase.java
@@ -1,15 +1,15 @@
 package springboot.database;
 
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
+
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
 
 public class InitializeDatabase {
 
@@ -19,13 +19,70 @@ public class InitializeDatabase {
 
     public static void main(String[] args) {
         String csvFilePath = "spring-boot/src/main/resources/products.csv";
+        dropTables();
+        Setup.initialize();
         insertAdmin();
         insertClerk();
         readAndInsertProducts(csvFilePath);
     }
 
+    public static void dropTables() {
+        Connection connection = Setup.getDBConnection();
+
+        try {
+            // Disable auto-commit to manage transactions manually
+            connection.setAutoCommit(false);
+
+            // Get the list of all tables
+            List<String> tables = new ArrayList<>();
+            DatabaseMetaData metaData = connection.getMetaData();
+            try (ResultSet rs = metaData.getTables(null, null, null, new String[]{"TABLE"})) {
+                while (rs.next()) {
+                    tables.add(rs.getString("TABLE_NAME"));
+                }
+            }
+
+            // Drop foreign key constraints and then drop tables
+            for (String table : tables) {
+                dropForeignKeyConstraints(connection, table);
+                try (Statement stmt = connection.createStatement()) {
+                    stmt.executeUpdate("DROP TABLE \"" + table + "\"");
+                    System.out.println("Dropped table: " + table);
+                }
+            }
+
+            connection.commit();
+        } catch (SQLException e) {
+            try {
+                connection.rollback();
+                System.err.println("Transaction rolled back due to an error: " + e.getMessage());
+            } catch (SQLException ex) {
+                System.err.println("Error during rollback: " + ex.getMessage());
+            }
+        } finally {
+            try {
+                connection.setAutoCommit(true);
+            } catch (SQLException ex) {
+                System.err.println("Error restoring auto-commit mode: " + ex.getMessage());
+            }
+        }
+    }
+
+    private static void dropForeignKeyConstraints(Connection conn, String tableName) throws SQLException {
+        try (Statement stmt = conn.createStatement(); ResultSet rs = conn.getMetaData().getExportedKeys(null, null, tableName)) {
+            while (rs.next()) {
+                String fkName = rs.getString("FK_NAME");
+                String fkTable = rs.getString("FKTABLE_NAME");
+                if (fkName != null) {
+                    stmt.executeUpdate("ALTER TABLE \"" + fkTable + "\" DROP CONSTRAINT \"" + fkName + "\"");
+                }
+            }
+        }
+    }
+
     public static void insertAdmin() {
-        try (Connection connection = DriverManager.getConnection(DB_CONNECTION, DB_USER, DB_PASSWORD)) {
+
+        try (Connection connection = Setup.getDBConnection()) {
             String sql = "INSERT INTO USERS (name, username, password, userType) VALUES (?, ?, ?, ?)";
             try (PreparedStatement statement = connection.prepareStatement(sql)) {
                 statement.setString(1, "admin");
@@ -41,7 +98,7 @@ public class InitializeDatabase {
     }
 
     public static void insertClerk() {
-        try (Connection connection = DriverManager.getConnection(DB_CONNECTION, DB_USER, DB_PASSWORD)) {
+        try (Connection connection = Setup.getDBConnection()) {
             String sql = "INSERT INTO USERS (name, username, password, userType) VALUES (?, ?, ?, ?)";
             try (PreparedStatement statement = connection.prepareStatement(sql)) {
                 statement.setString(1, "clerk");
@@ -57,13 +114,9 @@ public class InitializeDatabase {
     }
 
     private static void readAndInsertProducts(String filePath) {
-        try (Connection connection = DriverManager.getConnection(DB_CONNECTION, DB_USER, DB_PASSWORD);
-             Reader reader = new FileReader(filePath)) {
+        try (Connection connection = Setup.getDBConnection(); Reader reader = new FileReader(filePath)) {
 
-            CSVParser parser = new CSVParser(reader, CSVFormat.DEFAULT
-                    .withFirstRecordAsHeader()
-                    .withIgnoreHeaderCase()
-                    .withTrim());
+            CSVParser parser = new CSVParser(reader, CSVFormat.DEFAULT.withFirstRecordAsHeader().withIgnoreHeaderCase().withTrim());
 
             String query = "INSERT INTO PRODUCTS (productStock, productName, category, productPrice, productDescription, imageURL) VALUES (?, ?, ?, ?, ?, ?)";
             PreparedStatement preparedStatement = connection.prepareStatement(query);


### PR DESCRIPTION
Changes
- Add `dropTables` to `InitializeDatabase`
- Add `dropForeignKeyConstraints` to InitializeDatabase

Effects
- All tables in database are `DROP`ped and new tables are created and filled with data every time the application is run